### PR TITLE
Chore: fix bug of resolving module in RN metro bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
-.build
+build
 dist

--- a/packages/adapter-dedupe/package.json
+++ b/packages/adapter-dedupe/package.json
@@ -2,22 +2,17 @@
   "name": "redux-api-call-adapter-dedupe",
   "version": "1.0.0",
   "description": "redux-api-call (npm.im/redux-api-call) adapter to dedupe similar request\"",
-  "main": ".build/index.js",
+  "main": "build/index.js",
   "repository": "tungv/redux-api-call",
   "author": "Tung Vu <me@tungv.com>",
   "license": "MIT",
   "babel": {
-    "presets": [
-      "stage-3",
-      "env"
-    ],
-    "plugins": [
-      "transform-runtime"
-    ]
+    "presets": ["stage-3", "env"],
+    "plugins": ["transform-runtime"]
   },
   "scripts": {
-    "build": "babel ./src -d ./.build",
-    "build:clean": "rm -rf ./.build",
+    "build": "babel ./src -d ./build",
+    "build:clean": "rm -rf ./build",
     "prepublish": "npm run build"
   },
   "devDependencies": {

--- a/packages/adapter-fetch/package.json
+++ b/packages/adapter-fetch/package.json
@@ -2,22 +2,17 @@
   "name": "redux-api-call-adapter-fetch",
   "version": "1.1.0",
   "description": "redux-api-call (npm.im/redux-api-call) adapter to fetch data using HTML5 Fetch API",
-  "main": ".build/index.js",
+  "main": "build/index.js",
   "repository": "tungv/redux-api-call",
   "author": "Tung Vu <me@tungv.com>",
   "license": "MIT",
   "babel": {
-    "presets": [
-      "stage-3",
-      "env"
-    ],
-    "plugins": [
-      "transform-runtime"
-    ]
+    "presets": ["stage-3", "env"],
+    "plugins": ["transform-runtime"]
   },
   "scripts": {
-    "build": "babel ./src -d ./.build",
-    "build:clean": "rm -rf ./.build",
+    "build": "babel ./src -d ./build",
+    "build:clean": "rm -rf ./build",
     "prepublish": "npm run build"
   },
   "devDependencies": {

--- a/packages/adapter-json/package.json
+++ b/packages/adapter-json/package.json
@@ -2,22 +2,17 @@
   "name": "redux-api-call-adapter-json",
   "version": "1.0.0",
   "description": "redux-api-call (npm.im/redux-api-call) adapter to parse JSON response and fallback to raw text\"",
-  "main": ".build/index.js",
+  "main": "build/index.js",
   "repository": "tungv/redux-api-call",
   "author": "Tung Vu <me@tungv.com>",
   "license": "MIT",
   "babel": {
-    "presets": [
-      "stage-3",
-      "env"
-    ],
-    "plugins": [
-      "transform-runtime"
-    ]
+    "presets": ["stage-3", "env"],
+    "plugins": ["transform-runtime"]
   },
   "scripts": {
-    "build": "babel ./src -d ./.build",
-    "build:clean": "rm -rf ./.build",
+    "build": "babel ./src -d ./build",
+    "build:clean": "rm -rf ./build",
     "prepublish": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
RN metro bundler can't resolve paths that have dot char (`.`). This PR change the build dist from `.build` to `build` for 3 adapter packages