### PR TITLE
chore: Export RESET_LOCAL constant

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -11,6 +11,7 @@ import {
   ACTION_FETCH_COMPLETE,
   ACTION_FETCH_FAILURE,
   ACTION_UPDATE_LOCAL,
+  ACTION_RESET_LOCAL
 } from './constants';
 import reducer from './reducer'
 
@@ -20,6 +21,7 @@ const ACTIONS = {
   COMPLETE: ACTION_FETCH_COMPLETE,
   FAILURE: ACTION_FETCH_FAILURE,
   UPDATE_LOCAL: ACTION_UPDATE_LOCAL,
+  RESET_LOCAL: ACTION_RESET_LOCAL
 };
 
 export const defaultTransformers = [dedupe, json, fetch];


### PR DESCRIPTION
When implementing the resetter, @tvkhoa forgot to export `ACTION_RESET_LOCAL` constant. 
This PR is to do it.