### PR TITLE
Feat: Add disposer action creator

### DIFF
--- a/packages/core/src/__tests__/makeFetchAction.spec.js
+++ b/packages/core/src/__tests__/makeFetchAction.spec.js
@@ -124,6 +124,16 @@ describe('makeFetchAction', () => {
       });
     });
 
+    describe('disposer', () => {
+      it('should return dispose action of correct apiName', () => {
+        const action = actual.disposer();
+        expect(action).toEqual({
+          type: '@@api/DISPOSE',
+          payload: { name: 'SAMPLE' },
+        });
+      });
+    });
+
     describe('selectors', () => {
       describe('isFetchingSelector', () => {
         it('should return isFetching in state if present', () => {

--- a/packages/core/src/__tests__/reducer.spec.js
+++ b/packages/core/src/__tests__/reducer.spec.js
@@ -309,4 +309,48 @@ describe('reducer', () => {
     });
 
   });
+
+  describe('ACTION_DISPOSE handler', () => {
+    const state = {
+      SAMPLE_1: {
+        lastResponse: 'lastResponse of sample 1',
+        lastRequest: 'lastRequest of sample 1',
+        isInvalidated: 'isInvalidated of sample 1',
+        isFetching: 'isFetching of sample 1',
+        error: 'error of sample 1',
+        data: {
+          key: 'value of sample 1'
+        },
+      },
+      SAMPLE_2: {
+        lastResponse: 'lastResponse of sample 2',
+        lastRequest: 'lastRequest of sample 2',
+        isInvalidated: 'isInvalidated of sample 2',
+        isFetching: 'isFetching of sample 2',
+        error: 'error of sample 2',
+        data: {
+          key: 'value of sample 2'
+        },
+      }
+    };
+
+    it('should dispose of the data of the apiName', () => {
+      const actual = reducer(state, { type: '@@api/DISPOSE', payload: { name: 'SAMPLE_1' } });
+      const expected = {
+        SAMPLE_1: undefined,
+        SAMPLE_2: {
+          lastResponse: 'lastResponse of sample 2',
+          lastRequest: 'lastRequest of sample 2',
+          isInvalidated: 'isInvalidated of sample 2',
+          isFetching: 'isFetching of sample 2',
+          error: 'error of sample 2',
+          data: {
+            key: 'value of sample 2'
+          },
+        }
+      };
+
+      expect(actual).to.deep.equal(expected);
+    });
+  });
 });

--- a/packages/core/src/__tests__/reducer.spec.js
+++ b/packages/core/src/__tests__/reducer.spec.js
@@ -313,44 +313,35 @@ describe('reducer', () => {
   describe('ACTION_DISPOSE handler', () => {
     const state = {
       SAMPLE_1: {
-        lastResponse: 'lastResponse of sample 1',
-        lastRequest: 'lastRequest of sample 1',
-        isInvalidated: 'isInvalidated of sample 1',
-        isFetching: 'isFetching of sample 1',
-        error: 'error of sample 1',
         data: {
           key: 'value of sample 1'
         },
       },
       SAMPLE_2: {
-        lastResponse: 'lastResponse of sample 2',
-        lastRequest: 'lastRequest of sample 2',
-        isInvalidated: 'isInvalidated of sample 2',
-        isFetching: 'isFetching of sample 2',
-        error: 'error of sample 2',
         data: {
           key: 'value of sample 2'
         },
       }
     };
 
-    it('should dispose of the data of the apiName', () => {
-      const actual = reducer(state, { type: '@@api/DISPOSE', payload: { name: 'SAMPLE_1' } });
-      const expected = {
-        SAMPLE_1: undefined,
-        SAMPLE_2: {
-          lastResponse: 'lastResponse of sample 2',
-          lastRequest: 'lastRequest of sample 2',
-          isInvalidated: 'isInvalidated of sample 2',
-          isFetching: 'isFetching of sample 2',
-          error: 'error of sample 2',
-          data: {
-            key: 'value of sample 2'
-          },
-        }
-      };
+    const setup = (apiName) => reducer(state, { type: '@@api/DISPOSE', payload: { name: apiName } });
 
-      expect(actual).to.deep.equal(expected);
-    });
+    describe('there is data of the apiName in state', () => {
+      it('should dispose of the data of the apiName', () => {
+        expect(setup('SAMPLE_1')).to.deep.equal({
+          SAMPLE_2: {
+            data: {
+              key: 'value of sample 2'
+            },
+          }
+        });
+      });
+    })
+
+    describe('there is NO data of the apiName in state', () => {
+      it('should return state', () => {
+        expect(setup('SAMPLE_3')).to.deep.equal(state);
+      });
+    })
   });
 });

--- a/packages/core/src/__tests__/reducer.spec.js
+++ b/packages/core/src/__tests__/reducer.spec.js
@@ -340,7 +340,7 @@ describe('reducer', () => {
 
     describe('there is NO data of the apiName in state', () => {
       it('should return state', () => {
-        expect(setup('SAMPLE_3')).to.deep.equal(state);
+        expect(setup('SAMPLE_3')).to.equal(state);
       });
     })
   });

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -4,3 +4,4 @@ export const ACTION_FETCH_COMPLETE = '@@api/FETCH_COMPLETE';
 export const ACTION_FETCH_FAILURE = '@@api/FETCH_FAILURE';
 export const ACTION_UPDATE_LOCAL = '@@api/UPDATE_LOCAL';
 export const ACTION_RESET_LOCAL = '@@api/RESET_LOCAL';
+export const ACTION_DISPOSE = '@@api/DISPOSE';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,6 +12,7 @@ import {
   ACTION_FETCH_FAILURE,
   ACTION_UPDATE_LOCAL,
   ACTION_RESET_LOCAL
+  ACTION_DISPOSE
 } from './constants';
 import reducer from './reducer'
 
@@ -21,7 +22,8 @@ const ACTIONS = {
   COMPLETE: ACTION_FETCH_COMPLETE,
   FAILURE: ACTION_FETCH_FAILURE,
   UPDATE_LOCAL: ACTION_UPDATE_LOCAL,
-  RESET_LOCAL: ACTION_RESET_LOCAL
+  RESET_LOCAL: ACTION_RESET_LOCAL,
+  DISPOSE: ACTION_DISPOSE
 };
 
 export const defaultTransformers = [dedupe, json, fetch];

--- a/packages/core/src/makeFetchAction.js
+++ b/packages/core/src/makeFetchAction.js
@@ -2,6 +2,7 @@ import {
   ACTION_FETCH_START,
   ACTION_RESET_LOCAL,
   ACTION_UPDATE_LOCAL,
+  ACTION_DISPOSE,
   REDUCER_PATH,
 } from './constants';
 import get from './utils/get';
@@ -49,6 +50,11 @@ export default (apiName, apiConfigFn, selectorDescriptor = {}) => {
     },
   });
 
+  const disposer = () => ({
+    type: ACTION_DISPOSE,
+    payload: { name: apiName }
+  })
+
   const isFetchingSelector = get([REDUCER_PATH, apiName, 'isFetching'], false);
   const isInvalidatedSelector = get([REDUCER_PATH, apiName, 'isInvalidated'], false);
   const dataSelector = get([REDUCER_PATH, apiName, 'data'], null);
@@ -66,5 +72,6 @@ export default (apiName, apiConfigFn, selectorDescriptor = {}) => {
     errorSelector,
     lastResponseSelector,
     resetter,
+    disposer
   };
 };

--- a/packages/core/src/reducer.js
+++ b/packages/core/src/reducer.js
@@ -77,7 +77,13 @@ const reducer = handleActions({
       }
     );
   },
-  [ACTION_DISPOSE]: (state, action) => ({ ...state, [getName(action)]: undefined})
+  [ACTION_DISPOSE]: (state, action) => {
+    const apiName = getName(action);
+    if (state.hasOwnProperty(apiName)) {
+      delete state[apiName];
+    }
+    return state;
+  }
 });
 
 export default reducer;

--- a/packages/core/src/reducer.js
+++ b/packages/core/src/reducer.js
@@ -80,7 +80,8 @@ const reducer = handleActions({
   [ACTION_DISPOSE]: (state, action) => {
     const apiName = getName(action);
     if (state.hasOwnProperty(apiName)) {
-      delete state[apiName];
+      const {[apiName]: disposed, ...newState} = state;
+      return newState;
     }
     return state;
   }

--- a/packages/core/src/reducer.js
+++ b/packages/core/src/reducer.js
@@ -4,6 +4,7 @@ import {
   ACTION_FETCH_FAILURE,
   ACTION_UPDATE_LOCAL,
   ACTION_RESET_LOCAL,
+  ACTION_DISPOSE,
 } from './constants';
 import handleActions from './utils/handleActions';
 
@@ -76,6 +77,7 @@ const reducer = handleActions({
       }
     );
   },
+  [ACTION_DISPOSE]: (state, action) => ({ ...state, [getName(action)]: undefined})
 });
 
 export default reducer;


### PR DESCRIPTION
As discussed in PR #50, this PR is to add `disposer` action creator to dispose of all the data of an API name from the state.