### PR TITLE
Feature: Add dataTransform which customizes dataSelector

### DIFF
--- a/packages/core/src/__tests__/makeFetchAction.spec.js
+++ b/packages/core/src/__tests__/makeFetchAction.spec.js
@@ -239,4 +239,45 @@ describe('makeFetchAction', () => {
       });
     });
   });
+  describe('with custom dataTransform', () => {
+    let actual;
+    let configFn;
+
+    beforeAll(() => {
+      timekeeper.freeze(NOW);
+    });
+
+    beforeAll(() => {
+      configFn = jest.fn(constant({ endpoint: 'http://example.com' }));
+      const dataTransform = data => {
+        return {
+          ...data,
+          transformed: true,
+        };
+      };
+      actual = makeFetchAction('SAMPLE', configFn, dataTransform);
+    });
+
+    describe('dataSelector', () => {
+      it('should return data in state if present', () => {
+        const data = { key: 'value' };
+        expect(
+          actual.dataSelector({
+            api_calls: {
+              SAMPLE: {
+                data,
+              },
+            },
+          }),
+        ).toEqual({
+          key: 'value',
+          transformed: true,
+        });
+      });
+
+      it('should return null if api was not called', () => {
+        expect(actual.dataSelector({})).toBe(null);
+      });
+    });
+  });
 });

--- a/packages/core/src/makeFetchAction.js
+++ b/packages/core/src/makeFetchAction.js
@@ -56,6 +56,19 @@ export default (apiName, apiConfigFn, selectorDescriptor = {}) => {
   const errorSelector = get([REDUCER_PATH, apiName, 'error'], null);
   const lastResponseSelector = get([REDUCER_PATH, apiName, 'lastResponse'], null);
 
+  const dataSelector = state => {
+    const data = get([REDUCER_PATH, apiName, 'data'], null)(state);
+    if (dataTransform && data) {
+      return dataTransform(data);
+    } else {
+      return data;
+    }
+  };
+
+  const headersSelector = get([REDUCER_PATH, apiName, 'headers'], null);
+  const errorSelector = get([REDUCER_PATH, apiName, 'error'], null);
+  const lastResponseSelector = get([REDUCER_PATH, apiName, 'lastResponse'], null);
+
   return {
     actionCreator,
     updater,


### PR DESCRIPTION
- Add dataTransform which customizes dataSelector.
- Example: We define a dataTransform which adds a key `tranformed: true`. We expect result should have key `transformed:true`

 ```
   configFn = jest.fn(constant({ endpoint: 'http://example.com' }));
      const dataTransform = data => {
        return {
          ...data,
          transformed: true,
        };
      };
      actual = makeFetchAction('SAMPLE', configFn, dataTransform);
```
Expected result:
```
  const data = { key: 'value' };
        expect(
          actual.dataSelector({
            api_calls: {
              SAMPLE: {
                data,
              },
            },
          }),
        ).toEqual({
          key: 'value',
          transformed: true,
        });
      });

```