### PR TITLE
feat: reset headers when ACTION_RESET_LOCAL is dispatched

### DIFF
--- a/packages/core/src/reducer.js
+++ b/packages/core/src/reducer.js
@@ -74,6 +74,7 @@ const reducer = handleActions({
         lastResponse: resetOrKeepValue('lastResponse', action, currentData),
         data: resetOrKeepValue('data', action, currentData),
         error: resetOrKeepValue('error', action, currentData),
+        headers: resetOrKeepValue('headers', action, currentData),
       }
     );
   },


### PR DESCRIPTION
Hi there, as current `headers` response is not reset as it should be when you dispatch `ACTION_RESET_LOCAL`, this quick change aims to address that, thanks in advance!